### PR TITLE
Verify paths provided are strings.

### DIFF
--- a/pdf2doi/finders.py
+++ b/pdf2doi/finders.py
@@ -601,6 +601,10 @@ def add_found_identifier_to_metadata(target,identifier):
     -------
     True if the the metadata was added succesfully, false otherwise
     """
+    
+    # Make sure the path is a string in case a Pathlib object is provided
+    target = str(target)
+    
     add_metadata(target,key='/pdf2doi_identifier',value=identifier)
 
 

--- a/pdf2doi/main.py
+++ b/pdf2doi/main.py
@@ -46,6 +46,9 @@ def pdf2doi(target):
 
     logger = logging.getLogger("pdf2doi")
 
+    # Make sure the path is a string in case a Pathlib object is provided
+    target = str(target)
+    
     # Check if path is valid
     if not (path.exists(target)):
         logger.error(f"{target} is not a valid path to a file or a directory.")


### PR DESCRIPTION
Fixes a couple of entry points into the library to make sure the path provided is a string in case the provided path is a Pathlib object.