### PR TITLE
Make config file optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ options:
                         just right clicking on it! NOTE: this feature is only available on Windows.
   -uninstall--right--click
                         Uninstall the right-click context menu functionalities. NOTE: this feature is only available on Windows.
+  -cfg, --use_config_file
+                        Load settings from a config file at a default location. If --config_file_path isn't given, an INI file named 'settings.ini' will be created or read from the same directory as pdf2doi. The config file settings supersede CLI settings where they conflict. This argument isn't necessary if --config_file_path is given.
+  -cfg--path CONFIG_FILE_PATH, --config_file_path CONFIG_FILE_PATH
+                        Load settings from a config file at the given relative or absolute path. If a relative path is given, the path is relative to the pdf2doi script or executable. The config file settings supersede CLI settings where they conflict.
 ```
 
 #### Manually associate the correct identifier to a file from command line

--- a/pdf2doi/__init__.py
+++ b/pdf2doi/__init__.py
@@ -11,8 +11,6 @@ if not logger.handlers:
     logger.addHandler(ch)
 logger.propagate = False
 
-from .config import config
-config.ReadParamsINIfile()  #Load all current configuration from the .ini file. If the .ini file is not present, it generates it using default values
 
 #Determine the list of libraries to be used to extract text from pdf files
 reader_libraries = ['PyPdf','pdfminer'] 
@@ -23,8 +21,6 @@ if is_textract_installed:
     reader_libraries. append('textract')
     
 
-config.set('verbose',config.get('verbose')) #This is a quick and dirty way (to improve in the future) to make sure that the verbosity of the pdf2doi logger is properly set according
-                                            #to the current value of config.get('verbose') (see config.py file for details)
 from .main import pdf2doi, pdf2doi_singlefile
 from .finders import *
 #from .bibtex_makers import *

--- a/pdf2doi/config.py
+++ b/pdf2doi/config.py
@@ -73,15 +73,24 @@ class config():
             logger.setLevel(level=loglevel)
 
     @staticmethod
-    def ReadParamsINIfile():
+    def ReadParamsINIfile(path):
         '''
-        Reads the parameters stored in the file settings.ini, and stores them in the dict self.params
+        Reads the parameters stored in the .ini file given by path, and stores them in the dict self.params
         If the .ini file does not exist, it creates it with the default values.
         '''
-        path_current_directory = os.path.dirname(__file__)
-        path_config_file = os.path.join(path_current_directory, 'settings.ini')
-        if not(os.path.exists(path_config_file)):
-            config.WriteParamsINIfile()
+        if os.path.isabs(path):
+            path_config_file = path
+        else:
+            path_current_directory = os.path.dirname(__file__)
+            path_config_file = os.path.join(path_current_directory, path)
+
+        logger = logging.getLogger("pdf2doi")
+        if os.path.isdir(path_config_file):
+            logger.error(f"{path_config_file} is a path to a dir, not to a file.")
+            return None
+
+        if not os.path.exists(path_config_file):
+            config.WriteParamsINIfile(path_config_file)
         else:
             config_object = configparser.ConfigParser()
             config_object.optionxform = str
@@ -113,16 +122,14 @@ class config():
             print(key + " : " + str(val) + ' ('+type(val).__name__+')')
 
     @staticmethod
-    def WriteParamsINIfile():
+    def WriteParamsINIfile(path):
         '''
-        Writes the parameters currently stored in in the dict self.params into the file settings.ini
+        Writes the parameters currently stored in in the dict self.params into the file at path
         '''
-        path_current_directory = os.path.dirname(__file__)
-        path_config_file = os.path.join(path_current_directory, 'settings.ini')
         config_object = configparser.ConfigParser()
         config_object.optionxform = str
         config_object['DEFAULT'] = config.__params
-        with open(path_config_file, 'w') as configfile: #Write them on file
+        with open(path, 'w') as configfile: #Write them on file
             config_object.write(configfile)
 
 

--- a/pdf2doi/main.py
+++ b/pdf2doi/main.py
@@ -304,6 +304,14 @@ def main():
                         dest="uninstall_right_click",
                         action="store_true",
                         help="Uninstall the right-click context menu functionalities. NOTE: this feature is only available on Windows.")
+    parser.add_argument("-cfg",
+                        "--use_config_file",
+                        help="Load settings from a config file at a default location. If --config_file_path isn't given, an INI file named 'settings.ini' will be created or read from the same directory as pdf2doi. The config file settings supersede CLI settings where they conflict. This argument isn't necessary if --config_file_path is given.",
+                        action="store_true")
+    parser.add_argument("-cfg--path",
+                        "--config_file_path",
+                        help="Load settings from a config file at the given relative or absolute path. If a relative path is given, the path is relative to the pdf2doi script or executable. The config file settings supersede CLI settings where they conflict.",
+                        action="store")
 
     args = parser.parse_args()
 
@@ -362,6 +370,13 @@ def main():
 
     if args.google_results:
         config.set('numb_results_google_search', args.google_results)
+
+    config_path = "settings.ini"
+    if args.config_file_path:
+        config_path = args.config_file_path
+    if args.use_config_file or args.config_file_path:
+        config.ReadParamsINIfile(config_path)
+
     results = pdf2doi(target=target)
 
     if not results:


### PR DESCRIPTION
This fixes #29.

Problems this solves:
- users have control over if/how they want to use the config file
- config file path is customizable
- certain config file options weren't being used at all (for example, `verbose` was only controlled by the CLI)

Hopefully this doesn't break any use-cases/workflows. Let me know if there's anything you're skeptical about.