### PR TITLE
pdfminer.six version requirement changed to >=20221105

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pdftitle>=0.3
 feedparser>=6.0.2
 pyperclip
 easygui
-pdfminer.six==20221105
+pdfminer.six>=20221105
 pymupdf>=1.21.0
 pypdf


### PR DESCRIPTION
Hi @MicheleCotrufo, 

Thanks for this very useful library. 

#### Change:
I changed the pdfminer.six version requirement to **>=20221105**

#### Issure:
I faced some dependency errors. I'm using **CrewAI==0.100.1** which needs **pdfplumber 0.11.5**, and again that needs **pdfminer.six==20231228**. However, **pdf2doi==1.7** doesn't support **pdfminer.six==20231228**.

#### Tests:
I tested all the major functions of *pdf2doi* to check whether the newer pdfminer.six versions are breaking anything or not.